### PR TITLE
Pass selected score type to backend

### DIFF
--- a/src/easysnec/backend.py
+++ b/src/easysnec/backend.py
@@ -18,7 +18,7 @@ from PySide6.QtCore import (
     Property,
 )
 
-from .utils.grading import COURSES, InputData, SuccessStatus
+from .utils.grading import COURSES, InputData, SuccessStatus, ScoreType
 
 from enum import Enum
 
@@ -135,7 +135,7 @@ class BackendInterface(QObject):
     )
 
     # --- scoring mode property (rw)
-    _scoring_mode = None
+    _scoring_mode = 1
 
     def get_scoring_mode(self):
         return self._scoring_mode
@@ -147,7 +147,7 @@ class BackendInterface(QObject):
 
     scoringModeChanged = Signal(str)
     scoringMode = Property(
-        DummyClass.BackendScoreType,
+        int,
         get_scoring_mode,
         set_scoring_mode,
         notify=scoringModeChanged,  # ty: ignore[invalid-argument-type]
@@ -281,7 +281,7 @@ class Backend:
                 best_guess_course = input_data.get_closest_course(COURSES)
                 # runner_grade = input_data.score_against(best_guess_course, ScoreType( self.backend.backend_interface.scoringMode))
                 runner_grade = input_data.score_against(
-                    best_guess_course, BackendInterface.scoringMode
+                    best_guess_course, ScoreType(BackendInterface.scoringMode)
                 )
 
                 log.info("Correctness: " + pprint.pformat(runner_grade.status))

--- a/src/easysnec/qml/Main.qml
+++ b/src/easysnec/qml/Main.qml
@@ -171,8 +171,21 @@ ApplicationWindow {
                             text: "Scoring Mode:"
                         }
                         ComboBox {
-                            model: ["Score-O", "Animal-O"]
+                            id: scoring_mode_selector
+                            model: [
+                                { value: 1, text: "Score-O"},
+                                { value: 2, text: "Classic-O"},
+                                { value: 3, text: "Animal-O"},
+                            ]
+                            textRole: "text"
+                            valueRole: "value"
+                            onActivated: {
+                                backend.log("selected scoring mode: " + scoring_mode_selector.currentText + " " + scoring_mode_selector.currentValue)
+                                backend.scoringMode = scoring_mode_selector.currentValue
+                            }
                         }
+                        Binding { target: backend; property: "scoringMode"; value: scoring_mode_selector.currentValue }
+
                     }
                     RowLayout {
                         Label {

--- a/src/easysnec/utils/grading.py
+++ b/src/easysnec/utils/grading.py
@@ -24,7 +24,7 @@ class SuccessStatus(Enum):
 class ScoreType(Enum):
     SCORE_O = 1
     CLASSIC_O = 2
-    ANIMAL_O = 2  # Looks exactly like classic-o from our perspective. this might be an illegal use of an enum
+    ANIMAL_O = 3
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This has not been tested with hardware yet, but it appears to properly send the selected score type to the backend. There's issues with converting the selected value into an actual enum so we are just saving the associated integer value and converting into `ScoreMode` when accessing the saved value during grading.