### PR TITLE
Replace fastlog library with logging from Python standard library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pyside6>=6.9.2",
     "sireader>=1.1.3",
     "sportident>=1.2.8",
-    "fastlog",
     "pyxdameraulevenshtein>=1.9.0",
     "pydantic>=2.12.3",
 ]

--- a/src/easysnec/app.py
+++ b/src/easysnec/app.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import sys
+import argparse
+import logging
 import signal
-
-from fastlog import log
+import sys
 from pathlib import Path
 
 from PySide6.QtGui import QGuiApplication
@@ -12,12 +12,12 @@ from PySide6.QtQml import QQmlApplicationEngine
 from .backend import Backend
 from .utils.qt_interface import BackendInterface
 
-import argparse
+log = logging.getLogger(__name__)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument('--debug-console', action='store_true')
+    parser.add_argument("--debug-console", action="store_true")
     args = parser.parse_args()
 
     # Set up the application window
@@ -28,7 +28,9 @@ def main() -> None:
     # --- connect backend
     backend_interface = BackendInterface()
     context.setContextProperty("backend", backend_interface)
-    backend = Backend(backend_interface, engine, enable_debug_console=args.debug_console)
+    backend = Backend(
+        backend_interface, engine, enable_debug_console=args.debug_console
+    )
     backend.start()
 
     # TODO: This is prob how we embed files in the application

--- a/src/easysnec/backend.py
+++ b/src/easysnec/backend.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
+import logging
 import pprint
 import time
+
 import serial.tools.list_ports
-
-from fastlog import log
-from sportident import SIReaderReadout, SIReaderCardChanged, SIReaderException
-
 from PySide6.QtCore import (
-    QStringListModel,
-    QTimer,
-    QThread,
     QObject,
+    QStringListModel,
+    QThread,
+    QTimer,
 )
+from sportident import SIReaderCardChanged, SIReaderException, SIReaderReadout
 
-from .utils.grading import COURSES, InputData, SuccessStatus, ScoreType
+from .utils.grading import COURSES, InputData, ScoreType, SuccessStatus
+
+log = logging.getLogger(__name__)
 
 
 class Backend:
@@ -38,7 +39,6 @@ class Backend:
             self.console_worker.moveToThread(self.console_thread)
             self.backend_interface.backend_started.connect(self.console_worker.console)
 
-
         # TODO: this code should live in QML
         # This should ideally be implemented by changing
         def hack_respond_to_readout(runner_grade):
@@ -61,21 +61,25 @@ class Backend:
             self.engine.rootObjects()[0].setProperty(
                 "scoring_output", runner_grade.scoring_output
             )
+
         self.backend_interface.card_result_readout.connect(hack_respond_to_readout)
 
-
         def get_reader():
-            log.info(f'attempting to connect to port {self.backend_interface._selected_port}')
+            log.info(
+                f"attempting to connect to port {self.backend_interface._selected_port}"
+            )
 
             try:
                 self.reader_worker.si_reader = SIReaderReadout(
                     self.backend_interface._selected_port
                 )
-                log.success("connected!")
+                log.info("connected!")
                 self.reader_worker.si_is_ready = True
             except SIReaderException:
                 self.reader_worker.si_is_ready = False
-                raise RuntimeError(f"Could not open SI reader on port {self.backend_interface._selected_port}")
+                raise RuntimeError(
+                    f"Could not open SI reader on port {self.backend_interface._selected_port}"
+                )
 
         self.backend_interface.try_connect_to_si_reader.connect(get_reader)
 
@@ -92,7 +96,9 @@ class Backend:
             if old_port in current_ports:
                 self.backend_interface.set_selected_port(old_port)
             else:
-                log.warning(f'selected port {old_port} has disappeared from list {current_ports}. we must respond to this wisely')
+                log.warning(
+                    f"selected port {old_port} has disappeared from list {current_ports}. we must respond to this wisely"
+                )
 
         self.timer = QTimer(interval=500)  # msecs
         self.timer.timeout.connect(update_time)
@@ -110,14 +116,14 @@ class Backend:
         self.timer.stop()
         log.success("threads safely stopped")
 
-
-    def report_si_input(self, input_data:InputData):
+    def report_si_input(self, input_data: InputData):
         # when multiple courses are available, get_closest_course before grading
         best_guess_course = input_data.get_closest_course(COURSES)
 
         # runner_grade = input_data.score_against(best_guess_course, ScoreType( self.backend.backend_interface.scoringMode))
         runner_grade = input_data.score_against(
-            best_guess_course, ScoreType.ANIMAL_O
+            best_guess_course,
+            ScoreType.ANIMAL_O,
             # best_guess_course, BackendInterface.scoringMode
         )
 
@@ -132,19 +138,20 @@ class DebugConsole(QObject):
         super().__init__()
         self.backend = backend
 
-
     def console(self):
         backend = self.backend
         interface = self.backend.backend_interface
 
         from code import interact
-        interact('DEBUG CONSOLE', local=locals())
+
+        interact("DEBUG CONSOLE", local=locals())
+
 
 class ReaderWorker(QObject):
     def __init__(self, engine, backend):
         super().__init__()
         self.engine = engine
-        self.backend:Backend = backend
+        self.backend: Backend = backend
 
         self.si_is_ready = False
         self.si_reader = None
@@ -168,7 +175,9 @@ class ReaderWorker(QObject):
                     pass
 
                 # process output
-                self.backend.report_si_input(InputData.from_si_result(self.si_reader.read_sicard()))
+                self.backend.report_si_input(
+                    InputData.from_si_result(self.si_reader.read_sicard())
+                )
             except (SIReaderCardChanged, SIReaderException) as e:
                 # this exception (card removed too early) can be ignored
                 log.warning(f"exception: {e}")

--- a/src/easysnec/utils/qt_interface.py
+++ b/src/easysnec/utils/qt_interface.py
@@ -1,17 +1,19 @@
+import logging
 from enum import Enum
 
-from fastlog import log
+import serial.tools.list_ports
 from PySide6.QtCore import (
-    QStringListModel,
-    QObject,
+    Property,
     QEnum,
+    QObject,
+    QStringListModel,
     Signal,
     Slot,
-    Property,
 )
-import serial.tools.list_ports
+
 from .grading import Grade
 
+log = logging.getLogger(__name__)
 
 
 class DummyClass(QObject):
@@ -160,4 +162,3 @@ class BackendInterface(QObject):
 
     runningChanged = Signal(str)
     running = Property(bool, get_running, set_running, notify=runningChanged)  # ty: ignore[invalid-argument-type]
-

--- a/uv.lock
+++ b/uv.lock
@@ -126,7 +126,6 @@ name = "easysnec"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "fastlog" },
     { name = "pydantic" },
     { name = "pyserial" },
     { name = "pyside6" },
@@ -145,7 +144,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastlog" },
     { name = "pydantic", specifier = ">=2.12.3" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyside6", specifier = ">=6.9.2" },
@@ -160,18 +158,6 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "typeguard", specifier = ">=4.4.4" },
-]
-
-[[package]]
-name = "fastlog"
-version = "1.0.0b3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/e1/568bef9cdcc39a83028ab0108de036d139d06e529e75f12aebf591266d09/fastlog-1.0.0b3.tar.gz", hash = "sha256:5c0032fcad143adfe4cfbf38b38cf9e63c82966d226aa6c1bf5d6c5e6144c1cf", size = 15519, upload-time = "2020-04-28T19:39:20.272Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/62/07d69ddfcd609e4f5ab128f18a6f87b4180e7fa96b6627d17225fb694954/fastlog-1.0.0b3-py2.py3-none-any.whl", hash = "sha256:9c9edba27943dc9af4c6a286e22426fd069b4fc08e136b15ddb344d3935be44f", size = 13535, upload-time = "2020-04-28T19:39:19.147Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The fastlog library didn't provide us with extra functionality that we were actually using, so I'm switching to the standard library logging so the Mac app hopefully works.