### PR TITLE
hide settings button on setup page and set minimum window size

### DIFF
--- a/src/easysnec/qml/Main.qml
+++ b/src/easysnec/qml/Main.qml
@@ -41,6 +41,9 @@ ApplicationWindow {
     width: 640
     height: 480
 
+    minimumHeight: 400
+    minimumWidth: setup_pane.implicitWidth
+
     // colors!
     property var navgames_blue: "#0090f8"
     property var navgames_orange: "#ff683a"
@@ -72,7 +75,7 @@ ApplicationWindow {
             anchors.topMargin: 10
             anchors.bottomMargin: 10
 
-            height : buttons_group.implicitHeight
+            height : 40
             // implicitHeight:40
 
             uniformCellSizes: true
@@ -85,6 +88,7 @@ ApplicationWindow {
                 // }
                 Button {
                     text: "settings / back to configuration"
+                    visible: !root.show_start_page
                     onClicked: {
                         root.show_start_page = true;
                     }


### PR DESCRIPTION
Fixes #23 and tentatively fixes #21 (though minimum size is arbitrary). Minimum width is currently set to the width of the bottom bar so there shouldn't be overflow. Time label is kind of scuffed, but I think that is just a placeholder label.

Had to hardcode the header height so the header doesn't shrink when the button is invisible.

Screenshots taken without the dark mode changes.

<img width="788" height="632" alt="image" src="https://github.com/user-attachments/assets/3806af07-7913-44ce-8f31-0a5676ab011f" />

<img width="788" height="632" alt="image" src="https://github.com/user-attachments/assets/45d49a54-98c0-46e8-9812-ada4e04a1f1d" />
